### PR TITLE
Some fixes for MEAI.Evaluation sample

### DIFF
--- a/src/microsoft-extensions-ai-evaluation/api/INSTRUCTIONS.md
+++ b/src/microsoft-extensions-ai-evaluation/api/INSTRUCTIONS.md
@@ -19,6 +19,17 @@ All examples are included in [Examples.sln](./Examples.sln) and are structured a
 Then read on to learn
 [how to generate reports using the `aieval` dotnet tool](#generating-reports-using-the-aieval-dotnet-tool).
 
+**Note:** The examples included in this solution have been primarily tested against the GPT-4o model. The prompts
+present within the examples directly, as well as the prompts present within the evaluators included as part of the
+[Microsoft.Extensions.AI.Evaluation.Quality](https://www.nuget.org/packages/Microsoft.Extensions.AI.Evaluation.Quality)
+NuGet package (such as `CoherenceEvaluator`, `RelevanceTruthAndCompletenessEvaluator`, etc.) perform well against
+GPT-4o. However, they may not perform as well against other models. So, the evaluations performed in the examples may
+produce poor results against some other models.
+
+That said, it can still be an interesting exercise to try out the examples against other models to understand how
+different models perform (i.e., how quickly or slowly are they able to perform the evaluations, how accurately can they
+score the coherence, relevance, fluency, etc. of the supplied responses, and so on).
+
 ### Quick version
 
 1. Set the following environment variables. The most convenient option may be to set these environment variables
@@ -49,7 +60,7 @@ The following setup steps are required to set up the LLM connection / endpoint t
 
 1. **Select your LLM provider:** The examples are authored to run against Azure Open AI by default and have been tested
    against GPT-4o. You can easily switch to use Azure AI Inference, Ollama, or Open AI by changing one line of code
-   within [`TestSetup.GetChatConfiguration()`](./evaluation/Setup/TestSetup.cs#L24).
+   within [`TestSetup.GetChatConfiguration()`](./evaluation/Setup/TestSetup.cs#L25).
 
 2. **Configure environment variables that define the connection parameters for your LLM endpoint:** Open
    [`EnvironmentVariables.cs`](./evaluation/Setup/EnvironmentVariables.cs) to figure out the set of environment

--- a/src/microsoft-extensions-ai-evaluation/api/evaluation/Evaluation.csproj
+++ b/src/microsoft-extensions-ai-evaluation/api/evaluation/Evaluation.csproj
@@ -11,18 +11,18 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.0.1-preview.1.24570.5" />
-    <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.0.1-preview.1.24570.5" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="FluentAssertions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.1.0-preview.1.25064.3" />
+    <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.1.0-preview.1.25064.3" />
     <PackageReference Include="Microsoft.Extensions.AI.Evaluation" Version="0.9.56-preview" />
     <PackageReference Include="Microsoft.Extensions.AI.Evaluation.Quality" Version="0.9.56-preview" />
-    <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.0.1-preview.1.24570.5" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.0.1-preview.1.24570.5" />
-    <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.1.0-preview.1.25064.3" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.1.0-preview.1.25064.3" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/microsoft-extensions-ai-evaluation/api/evaluation/Setup/EnvironmentVariables.cs
+++ b/src/microsoft-extensions-ai-evaluation/api/evaluation/Setup/EnvironmentVariables.cs
@@ -39,11 +39,18 @@ public class EnvironmentVariables
         return value is not null;
     }
 
-    private static int GetInputTokenLimit(string variableName, int @default = 5000)
+    private static bool TryGetInputTokenLimit(string variableName, [NotNullWhen(true)] out int? limit)
     {
-        return TryGetEnvironmentVariable(variableName, out string? value) && int.TryParse(value, out int limit)
-            ? limit
-            : @default;
+        if (TryGetEnvironmentVariable(variableName, out string? value) && int.TryParse(value, out int valueInteger))
+        {
+            limit = valueInteger;
+            return true;
+        }
+        else
+        {
+            limit = null;
+            return false;
+        }
     }
 
     #region Azure AI Inference
@@ -56,8 +63,10 @@ public class EnvironmentVariables
     public static string AzureAIInferenceModel
         => GetEnvironmentVariable("EVAL_SAMPLE_AZURE_AI_INFERENCE_MODEL");
 
-    public static int AzureAIInferenceModelInputTokenLimit
-        => GetInputTokenLimit("EVAL_SAMPLE_AZURE_AI_INFERENCE_MODEL_INPUT_TOKEN_LIMIT");
+    public static int? AzureAIInferenceModelInputTokenLimit =>
+        TryGetInputTokenLimit("EVAL_SAMPLE_AZURE_AI_INFERENCE_MODEL_INPUT_TOKEN_LIMIT", out int? limit)
+            ? limit
+            : null;
     #endregion
 
     #region Azure OpenAI
@@ -67,8 +76,10 @@ public class EnvironmentVariables
     public static string AzureOpenAIModel
         => GetEnvironmentVariable("EVAL_SAMPLE_AZURE_OPENAI_MODEL");
 
-    public static int AzureOpenAIModelInputTokenLimit
-        => GetInputTokenLimit("EVAL_SAMPLE_AZURE_OPENAI_MODEL_INPUT_TOKEN_LIMIT");
+    public static int? AzureOpenAIModelInputTokenLimit =>
+        TryGetInputTokenLimit("EVAL_SAMPLE_AZURE_OPENAI_MODEL_INPUT_TOKEN_LIMIT", out int? limit)
+            ? limit
+            : null;
     #endregion
 
     #region Ollama
@@ -78,8 +89,10 @@ public class EnvironmentVariables
     public static string OllamaModel
         => GetEnvironmentVariable("EVAL_SAMPLE_OLLAMA_MODEL");
 
-    public static int OllamaModelInputTokenLimit
-        => GetInputTokenLimit("EVAL_SAMPLE_OLLAMA_MODEL_INPUT_TOKEN_LIMIT");
+    public static int? OllamaModelInputTokenLimit =>
+        TryGetInputTokenLimit("EVAL_SAMPLE_OLLAMA_MODEL_INPUT_TOKEN_LIMIT", out int? limit)
+            ? limit
+            : null;
     #endregion
 
     #region OpenAI
@@ -89,8 +102,10 @@ public class EnvironmentVariables
     public static string OpenAIModel
         => GetEnvironmentVariable("EVAL_SAMPLE_OPENAI_MODEL");
 
-    public static int OpenAIModelInputTokenLimit
-        => GetInputTokenLimit("EVAL_SAMPLE_OPENAI_MODEL_INPUT_TOKEN_LIMIT");
+    public static int? OpenAIModelInputTokenLimit =>
+        TryGetInputTokenLimit("EVAL_SAMPLE_OPENAI_MODEL_INPUT_TOKEN_LIMIT", out int? limit)
+            ? limit
+            : null;
     #endregion
 
     public static string StorageRootPath

--- a/src/microsoft-extensions-ai-evaluation/api/evaluation/Setup/TestSetup.cs
+++ b/src/microsoft-extensions-ai-evaluation/api/evaluation/Setup/TestSetup.cs
@@ -8,6 +8,7 @@ using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.AI.Evaluation;
+using Microsoft.Extensions.AI.Evaluation.Quality;
 using Microsoft.ML.Tokenizers;
 using OpenAI;
 
@@ -17,11 +18,30 @@ public class TestSetup
 {
     private static ChatConfiguration? s_chatConfiguration;
 
+    /// <summary>
+    /// Returns an instance of Microsoft.Extensions.AI.Evaluation's <see cref="ChatConfiguration"/>.
+    /// </summary>
+    /// <remarks>
+    /// All the evaluations performed in the included examples will use the returned <see cref="ChatConfiguration"/> to
+    /// communicate with the LLM.
+    /// </remarks>
     public static ChatConfiguration GetChatConfiguration()
     {
         if (s_chatConfiguration is null)
         {
             s_chatConfiguration = GetAzureOpenAIChatConfiguration(); // Switch this to any of the below providers as needed.
+
+            /// Note: The examples included in this solution have been primarily tested against the GPT-4o model. The
+            /// prompts present within the examples directly, as well as the prompts present within the
+            /// evaluators included as part of the Microsoft.Extensions.AI.Evaluation.Quality NuGet package (such as
+            /// <see cref="CoherenceEvaluator"/>, <see cref="RelevanceTruthAndCompletenessEvaluator"/>, etc.) perform
+            /// well against GPT-4o. However, they may not perform as well against other models. So, the evaluations
+            /// performed in the examples may produce poor results against some other models.
+            /// 
+            /// That said, it can still be an interesting exercise to try out the examples against other models to
+            /// understand how different models perform (i.e., how quickly or slowly are they able to perform the
+            /// evaluations, how accurately can they score the coherence, relevance, fluency, etc. of the supplied
+            /// responses, and so on).
         }
 
         return s_chatConfiguration;

--- a/src/microsoft-extensions-ai-evaluation/api/evaluation/Setup/TestSetup.cs
+++ b/src/microsoft-extensions-ai-evaluation/api/evaluation/Setup/TestSetup.cs
@@ -29,53 +29,116 @@ public class TestSetup
 
     private static ChatConfiguration GetAzureAIInferenceChatConfiguration()
     {
+        /// Get an instance of Microsoft.Extensions.AI's <see cref="IChatClient"/> interface for the selected LLM
+        /// endpoint.
         IChatClient client =
             new ChatCompletionsClient(
                 new Uri(EnvironmentVariables.AzureAIInferenceEndpoint),
                 new AzureKeyCredential(EnvironmentVariables.AzureAIInferenceAPIKey))
                     .AsChatClient(modelId: EnvironmentVariables.AzureAIInferenceModel);
 
-        IEvaluationTokenCounter tokenCounter =
+        IEvaluationTokenCounter? tokenCounter = null;
+        if (EnvironmentVariables.AzureAIInferenceModelInputTokenLimit.HasValue)
+        {
+            /// Note that while <see cref="TiktokenTokenizer"/> supports a wide variety of models, it may not (yet)
+            /// support the model you have selected. In this case, you can either turn off the token counting for all
+            /// evaluations performed in the included examples (by unsetting the above environment variable that
+            /// specifies the token limit), or you can implement <see cref="IEvaluationTokenCounter"/> for the selected
+            /// model (by wrapping any other tokenizer API that that supports the selected model) and pass this
+            /// <see cref="IEvaluationTokenCounter"/> down to the <see cref="ChatConfiguration"/> created below.
+            tokenCounter =
             TiktokenTokenizer.CreateForModel(EnvironmentVariables.AzureAIInferenceModel)
-                .ToTokenCounter(EnvironmentVariables.AzureAIInferenceModelInputTokenLimit);
+                    .ToTokenCounter(EnvironmentVariables.AzureAIInferenceModelInputTokenLimit.Value);
+        }
 
+        /// Create an instance of Microsoft.Extensions.AI.Evaluation's <see cref="ChatConfiguration"/>. All the
+        /// evaluations performed in the included examples will use this <see cref="ChatConfiguration"/> to communicate
+        /// with the LLM.
         return new ChatConfiguration(client, tokenCounter);
     }
 
     private static ChatConfiguration GetAzureOpenAIChatConfiguration()
     {
+        /// Get an instance of Microsoft.Extensions.AI's <see cref="IChatClient"/> interface for the selected LLM
+        /// endpoint.
         IChatClient client =
             new AzureOpenAIClient(new Uri(EnvironmentVariables.AzureOpenAIEndpoint), new DefaultAzureCredential())
                 .AsChatClient(modelId: EnvironmentVariables.AzureOpenAIModel);
 
-        IEvaluationTokenCounter tokenCounter =
+        IEvaluationTokenCounter? tokenCounter = null;
+        if (EnvironmentVariables.AzureOpenAIModelInputTokenLimit.HasValue)
+        {
+            /// Note that while <see cref="TiktokenTokenizer"/> supports a wide variety of models, it may not (yet)
+            /// support the model you have selected. In this case, you can either turn off the token counting for all
+            /// evaluations performed in the included examples (by unsetting the above environment variable that
+            /// specifies the token limit), or you can implement <see cref="IEvaluationTokenCounter"/> for the selected
+            /// model (by wrapping any other tokenizer API that that supports the selected model) and pass this
+            /// <see cref="IEvaluationTokenCounter"/> down to the <see cref="ChatConfiguration"/> created below.
+            tokenCounter =
             TiktokenTokenizer.CreateForModel(EnvironmentVariables.AzureOpenAIModel)
-                .ToTokenCounter(EnvironmentVariables.AzureOpenAIModelInputTokenLimit);
+                    .ToTokenCounter(EnvironmentVariables.AzureOpenAIModelInputTokenLimit.Value);
+        }
 
+        /// Create an instance of Microsoft.Extensions.AI.Evaluation's <see cref="ChatConfiguration"/>. All the
+        /// evaluations performed in the included examples will use this <see cref="ChatConfiguration"/> to communicate
+        /// with the LLM.
         return new ChatConfiguration(client, tokenCounter);
     }
 
     private static ChatConfiguration GetOllamaChatConfiguration()
     {
-        IChatClient client = new OllamaChatClient(new Uri(EnvironmentVariables.OllamaEndpoint));
+        /// Get an instance of Microsoft.Extensions.AI's <see cref="IChatClient"/> interface for the selected LLM
+        /// endpoint.
+        IChatClient client =
+            new OllamaChatClient(
+                new Uri(EnvironmentVariables.OllamaEndpoint),
+                modelId: EnvironmentVariables.OllamaModel);
 
-        IEvaluationTokenCounter tokenCounter =
+        IEvaluationTokenCounter? tokenCounter = null;
+        if (EnvironmentVariables.OllamaModelInputTokenLimit.HasValue)
+        {
+            /// Note that while <see cref="TiktokenTokenizer"/> supports a wide variety of models, it may not (yet)
+            /// support the model you have selected. In this case, you can either turn off the token counting for all
+            /// evaluations performed in the included examples (by unsetting the above environment variable that
+            /// specifies the token limit), or you can implement <see cref="IEvaluationTokenCounter"/> for the selected
+            /// model (by wrapping any other tokenizer API that that supports the selected model) and pass this
+            /// <see cref="IEvaluationTokenCounter"/> down to the <see cref="ChatConfiguration"/> created below.
+            tokenCounter =
             TiktokenTokenizer.CreateForModel(EnvironmentVariables.OllamaModel)
-                .ToTokenCounter(EnvironmentVariables.OllamaModelInputTokenLimit);
+                    .ToTokenCounter(EnvironmentVariables.OllamaModelInputTokenLimit.Value);
+        }
 
+        /// Create an instance of Microsoft.Extensions.AI.Evaluation's <see cref="ChatConfiguration"/>. All the
+        /// evaluations performed in the included examples will use this <see cref="ChatConfiguration"/> to communicate
+        /// with the LLM.
         return new ChatConfiguration(client, tokenCounter);
     }
 
     private static ChatConfiguration GetOpenAIChatConfiguration()
     {
+        /// Get an instance of Microsoft.Extensions.AI's <see cref="IChatClient"/> interface for the selected LLM
+        /// endpoint.
         IChatClient client =
             new OpenAIClient(EnvironmentVariables.OpenAIAPIKey)
                 .AsChatClient(modelId: EnvironmentVariables.OpenAIModel);
 
-        IEvaluationTokenCounter tokenCounter =
+        IEvaluationTokenCounter? tokenCounter = null;
+        if (EnvironmentVariables.OpenAIModelInputTokenLimit.HasValue)
+        {
+            /// Note that while <see cref="TiktokenTokenizer"/> supports a wide variety of models, it may not (yet)
+            /// support the model you have selected. In this case, you can either turn off the token counting for all
+            /// evaluations performed in the included examples (by unsetting the above environment variable that
+            /// specifies the token limit), or you can implement <see cref="IEvaluationTokenCounter"/> for the selected
+            /// model (by wrapping any other tokenizer API that that supports the selected model) and pass this
+            /// <see cref="IEvaluationTokenCounter"/> down to the <see cref="ChatConfiguration"/> created below.
+            tokenCounter =
             TiktokenTokenizer.CreateForModel(EnvironmentVariables.OpenAIModel)
-                .ToTokenCounter(EnvironmentVariables.OpenAIModelInputTokenLimit);
+                    .ToTokenCounter(EnvironmentVariables.OpenAIModelInputTokenLimit.Value);
+        }
 
+        /// Create an instance of Microsoft.Extensions.AI.Evaluation's <see cref="ChatConfiguration"/>. All the
+        /// evaluations performed in the included examples will use this <see cref="ChatConfiguration"/> to communicate
+        /// with the LLM.
         return new ChatConfiguration(client, tokenCounter);
     }
 }

--- a/src/microsoft-extensions-ai-evaluation/api/reporting/Reporting.csproj
+++ b/src/microsoft-extensions-ai-evaluation/api/reporting/Reporting.csproj
@@ -11,20 +11,20 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.0.1-preview.1.24570.5" />
-    <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.0.1-preview.1.24570.5" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="FluentAssertions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.1.0-preview.1.25064.3" />
+    <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.1.0-preview.1.25064.3" />
     <PackageReference Include="Microsoft.Extensions.AI.Evaluation" Version="0.9.56-preview" />
     <PackageReference Include="Microsoft.Extensions.AI.Evaluation.Quality" Version="0.9.56-preview" />
     <PackageReference Include="Microsoft.Extensions.AI.Evaluation.Reporting" Version="0.9.56-preview" />
-    <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.0.1-preview.1.24570.5" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.0.1-preview.1.24570.5" />
-    <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.1.0-preview.1.25064.3" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.1.0-preview.1.25064.3" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/microsoft-extensions-ai-evaluation/api/reporting/ReportingExamples.cs
+++ b/src/microsoft-extensions-ai-evaluation/api/reporting/ReportingExamples.cs
@@ -18,7 +18,7 @@ namespace Reporting;
 [TestClass]
 public partial class ReportingExamples
 {
-    /// NOTE: The value of the below property is populated by MSTest.
+    /// Note: The value of the below property is populated by MSTest.
     public TestContext? TestContext { get; set; }
 
     /// The execution name below is used to group evaluation results that are part of the same evaluation run (or test


### PR DESCRIPTION
* Fix samples to work correctly against Ollama. (`modelId` was not being passed)
* Make token counting completely optional to avoid exceptions by default when `TikTokenTokenizer` does not (yet) support the selected model.
* Include additional comments to explain how the `ChatConfiguration` is set up.
* Include some clarification around model choice in the instructions.
* Updated all referenced NuGet packages to latest.