### PR TITLE
Wrap FunctionInvokingChatClient with CachingChatClient instead of the other way around

### DIFF
--- a/src/microsoft-extensions-ai-evaluation/api/evaluation/Setup/TestSetup.cs
+++ b/src/microsoft-extensions-ai-evaluation/api/evaluation/Setup/TestSetup.cs
@@ -63,6 +63,9 @@ public class TestSetup
                 new AzureKeyCredential(EnvironmentVariables.AzureAIInferenceAPIKey))
                     .AsIChatClient(modelId: EnvironmentVariables.AzureAIInferenceModel);
 
+        /// Enable function invocation support.
+        client = client.AsBuilder().UseFunctionInvocation().Build();
+
         /// Create an instance of Microsoft.Extensions.AI.Evaluation's <see cref="ChatConfiguration"/>. All the
         /// evaluations performed in the included examples will use this <see cref="ChatConfiguration"/> to communicate
         /// with the LLM.
@@ -77,6 +80,9 @@ public class TestSetup
             new AzureOpenAIClient(new Uri(EnvironmentVariables.AzureOpenAIEndpoint), new DefaultAzureCredential())
                 .GetChatClient(EnvironmentVariables.AzureOpenAIModel)
                 .AsIChatClient();
+
+        /// Enable function invocation support.
+        client = client.AsBuilder().UseFunctionInvocation().Build();
 
         /// Create an instance of Microsoft.Extensions.AI.Evaluation's <see cref="ChatConfiguration"/>. All the
         /// evaluations performed in the included examples will use this <see cref="ChatConfiguration"/> to communicate
@@ -93,6 +99,9 @@ public class TestSetup
                 new Uri(EnvironmentVariables.OllamaEndpoint),
                 defaultModel: EnvironmentVariables.OllamaModel);
 
+        /// Enable function invocation support.
+        client = client.AsBuilder().UseFunctionInvocation().Build();
+
         /// Create an instance of Microsoft.Extensions.AI.Evaluation's <see cref="ChatConfiguration"/>. All the
         /// evaluations performed in the included examples will use this <see cref="ChatConfiguration"/> to communicate
         /// with the LLM.
@@ -107,6 +116,9 @@ public class TestSetup
             new OpenAIClient(EnvironmentVariables.OpenAIAPIKey)
                 .GetChatClient(EnvironmentVariables.OpenAIModel)
                 .AsIChatClient();
+
+        /// Enable function invocation support.
+        client = client.AsBuilder().UseFunctionInvocation().Build();
 
         /// Create an instance of Microsoft.Extensions.AI.Evaluation's <see cref="ChatConfiguration"/>. All the
         /// evaluations performed in the included examples will use this <see cref="ChatConfiguration"/> to communicate

--- a/src/microsoft-extensions-ai-evaluation/api/reporting/ReportingExamples.Example11_RunningAgentQualityEvaluators.cs
+++ b/src/microsoft-extensions-ai-evaluation/api/reporting/ReportingExamples.Example11_RunningAgentQualityEvaluators.cs
@@ -101,9 +101,6 @@ public partial class ReportingExamples
                 Tools = toolDefinitions
             };
 
-        /// Get an <see cref="IChatClient"/> with function calling enabled.
-        chatClient = chatClient.AsBuilder().UseFunctionInvocation().Build();
-
         ChatResponse response = await chatClient.GetResponseAsync(messages, chatOptions);
         return (messages, response, toolDefinitions);
     }


### PR DESCRIPTION
Response caching works reliably if a `FunctionInvokingChatClient` is wrapped with a `CachingChatClient`. The entire response (including cached function calls and results) are fetched from the cache in this case.

However, if a `CachingChatClient` is wrapped with a `FunctionInvokingChatClient` then caching only works partially. The initial tool call response message is fulfilled from the cache - but subsequent messages result in cache misses. This is because the function `callId`s produced by the LLM are not stable between independent runs even when the conversations are identical.

Now, it is debatable whether function calls and results should be cached at all (since tool implementations can change between independent runs and fetching responses from a cache could end up hiding / delaying discovery of product truth). However, in the specific case of the current evaluation examples, we want all unit tests to execute quickly on retry so that we can demonstrate that the caching works.